### PR TITLE
upgrade guzzle version (#110)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2 | ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request includes a small but significant change to the `composer.json` file. The change updates the version constraint for the `guzzlehttp/guzzle` package to allow for compatibility with both version 6.2 and version 7.0.

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L15-R15): Updated the `guzzlehttp/guzzle` version constraint to "^6.2 | ^7.0" to support both versions.